### PR TITLE
Scheduler breaking, can be canceled

### DIFF
--- a/src/App/NetDaemon.App/Common/Fluent.cs
+++ b/src/App/NetDaemon.App/Common/Fluent.cs
@@ -259,7 +259,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         /// <summary>
         ///     Excecute commands
         /// </summary>
-        void Execute();
+        ISchedulerResult Execute();
 
         /// <summary>
         ///     Use attribute on entity action in time actions
@@ -861,11 +861,11 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         }
 
         /// <inheritdoc/>
-        public void Execute()
+        public ISchedulerResult Execute()
         {
             _ = _entityManager ?? throw new NullReferenceException($"{nameof(_entityManager)} can not be null here!");
 
-            _daemon.Scheduler.RunEveryAsync(_timeSpan, async () => { await _entityManager.ExecuteAsync(true).ConfigureAwait(false); });
+            return _daemon.Scheduler.RunEvery(_timeSpan, async () => { await _entityManager.ExecuteAsync(true).ConfigureAwait(false); });
         }
 
         /// <inheritdoc/>

--- a/src/App/NetDaemon.App/Common/IScheduler.cs
+++ b/src/App/NetDaemon.App/Common/IScheduler.cs
@@ -1,69 +1,59 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace JoySoftware.HomeAssistant.NetDaemon.Common
 {
     /// <summary>
+    ///     Scheduler result lets you manage scheduled tasks like check completion, cancel the tasks etc.
+    /// </summary>
+    public interface ISchedulerResult
+    {
+        /// <summary>
+        ///     Current running task
+        /// </summary>
+        Task Task { get; }
+
+        /// <summary>
+        ///     Use to cancel any scheduled execution
+        /// </summary>
+        CancellationTokenSource CancelSource { get; }
+    }
+
+    /// <summary>
     ///     Interface for scheduler actions
     /// </summary>
     public interface IScheduler : IAsyncDisposable
     {
-        /// <summary>
-        ///     Run function every milliseconds
-        /// </summary>
-        /// <param name="millisecondsDelay">Number of milliseconds</param>
-        /// <param name="func">The function to run</param>
-        Task RunEveryAsync(int millisecondsDelay, Func<Task> func);
-
-        /// <summary>
-        ///     Run function every time span
-        /// </summary>
-        /// <param name="timeSpan">Timespan between runs</param>
-        /// <param name="func">The function to run</param>
-        Task RunEveryAsync(TimeSpan timeSpan, Func<Task> func);
-
-        /// <summary>
-        ///     Run in milliseconds delay
-        /// </summary>
-        /// <param name="millisecondsDelay">Number of milliseconds before run</param>
-        /// <param name="func">The function to run</param>
-        Task RunInAsync(int millisecondsDelay, Func<Task> func);
-
-        /// <summary>
-        ///     Run in function in time span
-        /// </summary>
-        /// <param name="timeSpan">Timespan time before run function</param>
-        /// <param name="func">The function to run</param>
-        Task RunInAsync(TimeSpan timeSpan, Func<Task> func);
 
         /// <summary>
         ///     Run function every milliseconds
         /// </summary>
         /// <param name="millisecondsDelay">Number of milliseconds</param>
         /// <param name="func">The function to run</param>
-        void RunEvery(int millisecondsDelay, Func<Task> func);
+        ISchedulerResult RunEvery(int millisecondsDelay, Func<Task> func);
 
         /// <summary>
         ///     Run function every time span
         /// </summary>
         /// <param name="timeSpan">Timespan between runs</param>
         /// <param name="func">The function to run</param>
-        void RunEvery(TimeSpan timeSpan, Func<Task> func);
+        ISchedulerResult RunEvery(TimeSpan timeSpan, Func<Task> func);
 
         /// <summary>
         ///     Run in milliseconds delay
         /// </summary>
         /// <param name="millisecondsDelay">Number of milliseconds before run</param>
         /// <param name="func">The function to run</param>
-        void RunIn(int millisecondsDelay, Func<Task> func);
+        ISchedulerResult RunIn(int millisecondsDelay, Func<Task> func);
 
         /// <summary>
         ///     Run in function in time span
         /// </summary>
         /// <param name="timeSpan">Timespan time before run function</param>
         /// <param name="func">The function to run</param>
-        void RunIn(TimeSpan timeSpan, Func<Task> func);
+        ISchedulerResult RunIn(TimeSpan timeSpan, Func<Task> func);
 
         /// <summary>
         ///     Run daily tasks
@@ -71,15 +61,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         /// <param name="time">The time in the format HH:mm:ss</param>
         /// <param name="func">The action to run</param>
         /// <returns></returns>
-        void RunDaily(string time, Func<Task> func);
-
-        /// <summary>
-        ///     Run daily tasks
-        /// </summary>
-        /// <param name="time">The time in the format HH:mm:ss</param>
-        /// <param name="func">The action to run</param>
-        /// <returns></returns>
-        Task RunDailyAsync(string time, Func<Task> func);
+        ISchedulerResult RunDaily(string time, Func<Task> func);
 
         /// <summary>
         ///     Run daily tasks
@@ -88,16 +70,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         /// <param name="func">The action to run</param>
         /// <param name="runOnDays">A list of days the scheduler will run on</param>
         /// <returns></returns>
-        void RunDaily(string time, IEnumerable<DayOfWeek>? runOnDays, Func<Task> func);
-
-        /// <summary>
-        ///     Run daily tasks
-        /// </summary>
-        /// <param name="time">The time in the format HH:mm:ss</param>
-        /// <param name="func">The action to run</param>
-        /// <param name="runOnDays">A list of days the scheduler will run on</param>
-        /// <returns></returns>
-        Task RunDailyAsync(string time, IEnumerable<DayOfWeek>? runOnDays, Func<Task> func);
+        ISchedulerResult RunDaily(string time, IEnumerable<DayOfWeek>? runOnDays, Func<Task> func);
 
         /// <summary>
         ///      Run task every minute at given second
@@ -107,16 +80,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         /// <remarks>
         ///     It is safe to supress the task since it is handled internally in the scheduler
         /// </remarks>
-        void RunEveryMinute(short second, Func<Task> func) => RunEveryMinuteAsync(second, func);
-
-        /// <summary>
-        ///      Run task every minute at given second
-        /// </summary>
-        /// <param name="second">The second in a minute to start (0-59)</param>
-        /// <param name="func">The task to run</param>
-        /// <remarks>
-        ///     It is safe to supress the task since it is handled internally in the scheduler
-        /// </remarks>
-        Task RunEveryMinuteAsync(short second, Func<Task> func);
+        ISchedulerResult RunEveryMinute(short second, Func<Task> func);
     }
 }


### PR DESCRIPTION
Fixes #10 .

Please adviced that alla async methods are removed from the API and could be breaking. You can change the metod in the sceduler to the non Async version and use `Task` on ISchedulerResult if you want to wait for the scheduled tasks for example.